### PR TITLE
Include `program drop` when sending program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.1] - 2017-11-19
+- Add restriction that code sent through Applescript can be max 8192 characters. https://www.stata.com/automation/#list
+- Include a line with `program drop myProgram` if it comes before `program define myProgram` when sending a program to Stata.
+
 ## [1.1.0] - 2017-11-19
 - Add XQuartz support. This allows code to be run on macOS in a session of Stata running on a remote server.
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ The following are the default keyboard shortcuts. These can be personalized in y
 - `shift-alt-p`: send the previous command.
 - `shift-cmd-c`: change Stata's working directory to that of current file.
 - `shift-cmd-g`: send paragraph under current cursor. A paragraph is a region enclosed by whitespace.
-- `shift-cmd-r`: send program definition under current cursor. For example, all the lines in the below snippet would be sent to Stata:
+- `shift-cmd-r`: send program definition under current cursor. If there exists `program drop` on the line before `program define`, the line including the former will be included in the selection. For example, all the lines in the below snippet would be sent to Stata:
 
     ```stata
+    cap program drop myProgram
     program define myProgram
         // program contents
     end

--- a/lib/stata-exec.js
+++ b/lib/stata-exec.js
@@ -185,7 +185,7 @@ module.exports = {
     currentPosition.row += 1;
     const backwardRange = [0, currentPosition];
     const funRegex = new
-      RegExp(/^\s*(pr(ogram|ogra|ogr|og|o)?)\s+(de(fine|fin|fi|f)?\s+)?[A-Za-z_][A-Za-z0-9_]{0,31}/g);
+      RegExp(/^\s*(pr(ogram|ogra|ogr|og|o)?)\s*(?!drop\s+)(de(fine|fin|fi|f)?)?\s*[A-Za-z_][A-Za-z0-9_]{0,31}/g);
     let foundStart = null;
     editor.backwardsScanInBufferRange(funRegex, backwardRange, function(result) {
       if (result.range.start.column === 0) {
@@ -197,6 +197,12 @@ module.exports = {
     if ((foundStart == null)) {
       console.error("Couldn't find the beginning of the function.");
       return null;
+    }
+
+    const dropRegex = new RegExp(/\s*pr(ogram|ogra|ogr|og|o)?\s+(drop)\s+[A-Za-z_][A-Za-z0-9_]{0,31}/g);
+    const textPrevRow = editor.lineTextForBufferRow(foundStart.start.row - 1);
+    if (dropRegex.test(textPrevRow) == true) {
+      foundStart.start.row -= 1;
     }
 
     // now look for the end


### PR DESCRIPTION
Include a line with `program drop myProgram` if it comes before `program define myProgram` when sending a program to Stata. Fixes https://github.com/kylebarron/stata-exec/issues/3