### PR TITLE
Fix comment removal to not touch comments in strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.2] - 2017-11-19
+- Fix comment removal to not touch comments in strings. Fixes https://github.com/kylebarron/stata-exec/issues/2
+    - Thanks to https://stackoverflow.com/questions/24518020/comprehensive-regexp-to-remove-javascript-comments
+
 ## [1.1.1] - 2017-11-19
 - Add restriction that code sent through Applescript can be max 8192 characters. https://www.stata.com/automation/#list
 - Include a line with `program drop myProgram` if it comes before `program define myProgram` when sending a program to Stata.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All configuration can be done in the settings panel (Settings > Packages > stata
 - Notifications
   - If checked, a pop-up notification will appear when a paragraph or function is not identified.
 - Skip Comments
-  - If this and Advance Position are checked, the after running a line, the cursor will move to the next uncommented line.
+  - If this and Advance Position are checked, after running a line the cursor will move to the next uncommented line.
 - Paste Speed
   - This is only applicable for XQuartz. This value changes the amount of time the program waits between switching to the XQuartz window, pasting code, and sending "enter". The only way to send code to XQuartz is to use the clipboard, and the responsiveness of this process will depend on the speed of your internet connection. If the copy-pasting isn't working, try increasing the value. Decreasing the value will run your code faster. Value must be between 0.1 and 10.
 
@@ -58,6 +58,4 @@ This package is currently Mac-only. I hope to add Windows support, but need to f
 ### Troubleshooting and Known Issues
 - _Do entire file_ doesn't run the last line of the do file.
   - Stata needs there to be a _newline_ character following the last line of text. Add an empty line to the end of the file and it'll work.
-- Stata's console doesn't accept comment characters like `//`, `///`, and `/* */`. This package thus must remove comments before running the code, but currently also removes those characters from strings. Hence you might find weird behavior if you have such characters in a string.
-
 

--- a/lib/stata-exec.js
+++ b/lib/stata-exec.js
@@ -145,10 +145,9 @@ module.exports = {
   },
 
   removeComments(code) {
-    code = code.replace(/\s*(\/\/\/).*\n?\s*/g, " ");
-    code = code.replace(/\s*\/\/.*/g, " ");
-    code = code.replace(/\/\*([\s\S]*?)\*\//gm, " "); // flags = re.DOTALL
-    code = code.replace(/[\t ]+/g, " ");
+    code = code.replace(/((["'])(?:\\[\s\S]|.)*?\2|(?:[^\w\s]|^)\s*\/(?![*\/])(?:\\.|\[(?:\\.|.)\]|.)*?\/(?=[gmiy]{0,4}\s*(?![*\/])(?:\W|$)))|\/\/.*?$|\/\*[\s\S]*?\*\//gm, '$1');
+    // https://stackoverflow.com/questions/24518020/comprehensive-regexp-to-remove-javascript-comments
+    // Using the "Final Boss Fight" at the bottom. Otherwise it fails on `di 5 / 5 // hello`
     return [code];
   },
 


### PR DESCRIPTION
Fixes https://github.com/kylebarron/stata-exec/issues/2

Thanks to https://stackoverflow.com/questions/24518020/comprehensive-regexp-to-remove-javascript-comments