### PR TITLE
Add Linux support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.0] - 2017-11-20
+- Add linux support.
+- Remove comments for all methods of sending code, not just 'send-command'
+- Change warnings from "can't find function" to "can't find program"
+
 ## [1.1.2] - 2017-11-19
 - Fix comment removal to not touch comments in strings. Fixes https://github.com/kylebarron/stata-exec/issues/2
     - Thanks to https://stackoverflow.com/questions/24518020/comprehensive-regexp-to-remove-javascript-comments

--- a/README.md
+++ b/README.md
@@ -1,29 +1,46 @@
 # stata-exec
 
-Send code to Stata from the [Atom](https://atom.io). _Note: This is for Mac only. Windows support is planned; Linux users can use [stata-autokey](https://github.com/kylebarron/stata-autokey)._ This was originally ported from the very good [r-exec](https://atom.io/packages/r-exec) package.
+Send code to Stata from [Atom](https://atom.io). _Note: This is for Mac and Linux only. Windows support is planned._ This was originally ported from the very good [r-exec](https://atom.io/packages/r-exec) package.
 
 ![run-command](./img/run_command.gif)
 
 ## News
-Version 1.1.0 includes the ability to run code in a session of Stata running on a remote server. See the configuration settings below for details.
+- Version 1.1.0 includes the ability to run code in a session of Stata running on a remote server. See the configuration settings below for details.
+- Version 1.2.0 adds support for Linux.
 
 ## Installation
 
-In the terminal run `apm install stata-exec` or go to Settings > Install and search for `stata-exec`. This package depends on [`language-stata`](https://atom.io/packages/language-stata), which you will be prompted to install if needed.
+In the terminal run `apm install stata-exec` or go to Settings > Install and search for `stata-exec`.
+
+### Dependencies
+
+This package depends on [`language-stata`](https://atom.io/packages/language-stata), which you will be prompted to install if needed. There are no additional dependencies needed for use on macOS.
+
+Linux users must install [Autokey](https://github.com/autokey-py3/autokey). On Ubuntu, that's as simple as:
+```
+sudo add-apt-repository ppa:troxor/autokey
+sudo apt update
+sudo apt install autokey-gtk
+```
+You must then add the [stata-exec.py](./linux/stata-exec.py) file to your Autokey data directory. This is `~/.config/autokey/data/` by default, so you can add the file to that directory with the command
+```
+wget https://github.com/kylebarron/stata-exec/blob/master/linux/stata-exec.py -O '~/.config/autokey/data/stata-exec.py'
+```
+This only needs to be done once. Additionally, the autokey program must be running for code sending to work. To do this, open up a new terminal and run `autokey-gtk`; this needs to be done every time you run code. (Alternatively, there's an option in Autokey's settings to start the program by default at login.)
 
 ## Usage
 
-Code can be run using either the Command Palette or with keyboard shortcuts. _Important: You must first select the flavor of Stata you own. See configuration settings [below](#configuration)._
+Code can be run using either the Command Palette or with keyboard shortcuts. _Important: If using macOS, you must first select the flavor of Stata you own. See configuration settings [below](#configuration)._
 
-To open the Command Palette, press `cmd-shift-P`, and then start typing `Stata Exec`. The available commands will be shown in the drop-down menu.
+To open the Command Palette, press `cmd-shift-P`/`ctrl-shift-P`, and then start typing `Stata Exec`. The available commands will be shown in the drop-down menu.
 
-The following are the default keyboard shortcuts. These can be personalized in your [`keymap.cson`](http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth/).
-- `cmd-enter`: send selection or current line to Stata.
-- `shift-cmd-d`: send entire file to Stata. (File must be saved first. This runs `do "/path/to/current/file"`)
-- `shift-alt-p`: send the previous command.
-- `shift-cmd-c`: change Stata's working directory to that of current file.
-- `shift-cmd-g`: send paragraph under current cursor. A paragraph is a region enclosed by whitespace.
-- `shift-cmd-r`: send program definition under current cursor. If there exists `program drop` on the line before `program define`, the line including the former will be included in the selection. For example, all the lines in the below snippet would be sent to Stata:
+The following are the default keyboard shortcuts (Mac/Linux). These can be personalized in your [`keymap.cson`](http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth/).
+- `cmd-enter`/`ctrl-enter`: send selection or current line to Stata.
+- `shift-cmd-D`/`shift-ctrl-D`: send entire file to Stata. (File must be saved first. This runs `do "/path/to/current/file"`)
+- `shift-alt-P`/`ctrl-alt-p`: send the previous command.
+- `shift-cmd-C`/`shift-ctrl-C`: change Stata's working directory to that of current file.
+- `shift-cmd-G`/`shift-ctrl-G`: send paragraph under current cursor. A paragraph is a region enclosed by whitespace.
+- `shift-cmd-R`/`shift-ctrl-R`: send program definition under current cursor. If there exists `program drop` on the line before `program define`, the line including the former will be included in the selection. For example, all the lines in the below snippet would be sent to Stata:
 
     ```stata
     cap program drop myProgram
@@ -39,6 +56,7 @@ All configuration can be done in the settings panel (Settings > Packages > stata
 - Which App
   - Select **StataIC**, **StataSE**, or **StataMP** depending on which version of Stata you have.
   - Select **XQuartz** if you want to run selections in session of Stata on a remote Unix server. To set this up, you need to have Stata already open in XQuartz; Atom will not open it for you. In your terminal, you'll need to do something like `ssh username@host -Y`, likely followed by `xstata`. This package's commands to run the entire do file and set the working directory are not supported on XQuartz.
+  - This setting currently has no effect on Linux.
 - Advance Position
   - If checked, move cursor to the next line/paragraph after running the current line/paragraph.
 - Focus Window
@@ -53,7 +71,7 @@ All configuration can be done in the settings panel (Settings > Packages > stata
 
 ## Notes
 
-This package is currently Mac-only. I hope to add Windows support, but need to figure out some Visual Basic or VBScript first. Linux users can use [stata-autokey](https://github.com/kylebarron/stata-autokey) to run selections in a GUI session of Stata.
+This package is currently only for Mac and Linux users. I hope to add Windows support, but need to figure out some Visual Basic or VBScript first.
 
 ### Troubleshooting and Known Issues
 - _Do entire file_ doesn't run the last line of the do file.

--- a/keymaps/stata-exec.cson
+++ b/keymaps/stata-exec.cson
@@ -21,3 +21,13 @@
   'shift-cmd-r': 'stata-exec:send-program'
   'shift-cmd-g': 'stata-exec:send-paragraph'
   'shift-alt-p': 'stata-exec:send-previous-command'
+
+'.platform-linux atom-text-editor[data-grammar="source stata"]:not([mini])':
+  'shift-ctrl-c': 'stata-exec:set-working-directory'
+  'ctrl-enter': 'stata-exec:send-command'
+  'shift-ctrl-d': 'stata-exec:do-entire-file'
+  'shift-ctrl-r': 'stata-exec:send-program'
+  'shift-ctrl-g': 'stata-exec:send-paragraph'
+  'ctrl-alt-p': 'stata-exec:send-previous-command'
+
+  

--- a/lib/stata-exec.js
+++ b/lib/stata-exec.js
@@ -131,7 +131,7 @@ module.exports = {
     // (if the user wants to)
     const currentPosition = editor.getLastSelection().getScreenRange().end;
     const selection = this.getSelection(whichApp);
-    this.sendCode(this.removeComments(selection.selection), whichApp);
+    this.sendCode(selection.selection, whichApp);
 
     const advancePosition = atom.config.get('stata-exec.advancePosition');
     if (advancePosition && !selection.anySelection) {
@@ -161,6 +161,7 @@ module.exports = {
   },
 
   sendCode(code, whichApp) {
+    code = removeComments(code)
     if (String(code).length > 8192 & (whichApp != "XQuartz" | process.platform == 'linux')) {
       console.error('Code selection must be fewer than 8192 characters');
       this.conditionalWarning("Code selection must be fewer than 8192 characters");

--- a/lib/stata-exec.js
+++ b/lib/stata-exec.js
@@ -202,7 +202,7 @@ module.exports = {
     });
 
     if ((foundStart == null)) {
-      console.error("Couldn't find the beginning of the function.");
+      console.error("Couldn't find the beginning of the program.");
       return null;
     }
 
@@ -225,7 +225,7 @@ module.exports = {
     });
 
     if ((foundEnd == null)) {
-      console.error("Couldn't find the end of the function.");
+      console.error("Couldn't find the end of the program.");
       return null;
     }
 
@@ -235,7 +235,7 @@ module.exports = {
         (currentPosition.row <= foundEnd.start.row)) {
       return new Range(foundStart.start, foundEnd.end);
     } else {
-      console.error("Couldn't find a function surrounding the current line.");
+      console.error("Couldn't find a program surrounding the current line.");
       console.error("start: ", foundStart);
       console.error("end: ", foundEnd);
       console.error("currentPosition: ", currentPosition);
@@ -253,7 +253,7 @@ module.exports = {
       code = code.addSlashes();
       return this.sendCode(code, whichApp);
     } else {
-      return this.conditionalWarning("Couldn't find function.");
+      return this.conditionalWarning("Couldn't find program.");
     }
   },
 

--- a/lib/stata-exec.js
+++ b/lib/stata-exec.js
@@ -9,7 +9,11 @@
 const {CompositeDisposable, Point, Range} = require('atom');
 
 String.prototype.addSlashes = function() {
-  return this.replace(/[\\"]/g, "\\$&").replace(/\u0000/g, "\\0");
+  if (process.platform == 'darwin') {
+    return this.replace(/[\\"]/g, "\\$&").replace(/\u0000/g, "\\0");
+  } else if (process.platform == 'linux') {
+    return this.replace(/\u0000/g, "\\0");
+  }
 };
 
 const apps = {
@@ -157,18 +161,22 @@ module.exports = {
   },
 
   sendCode(code, whichApp) {
-    if (String(code).length > 8192 & whichApp != "XQuartz") {
+    if (String(code).length > 8192 & (whichApp != "XQuartz" | process.platform == 'linux')) {
       console.error('Code selection must be fewer than 8192 characters');
       this.conditionalWarning("Code selection must be fewer than 8192 characters");
       return;
     } else {
       this.previousCommand = code;
-      switch (whichApp) {
-        case apps.stataIC: return this.stata(code, whichApp);
-        case apps.stataMP: return this.stata(code, whichApp);
-        case apps.stataSE: return this.stata(code, whichApp);
-        case apps.xquartz: return this.xquartz(code);
-        default: return console.error(`stata-exec.whichApp "${whichApp}" is not supported.`);
+      if (process.platform == 'darwin') {
+        switch (whichApp) {
+          case apps.stataIC: return this.stata_mac(code, whichApp);
+          case apps.stataMP: return this.stata_mac(code, whichApp);
+          case apps.stataSE: return this.stata_mac(code, whichApp);
+          case apps.xquartz: return this.xquartz(code);
+          default: return console.error(`stata-exec.whichApp "${whichApp}" is not supported.`);
+        }
+      } else if (process.platform == 'linux') {
+        return this.stata_linux(code, whichApp);
       }
     }
   },
@@ -418,7 +426,7 @@ module.exports = {
     }
   },
 
-  stata(selection, whichApp) {
+  stata_mac(selection, whichApp) {
     const osascript = require('node-osascript');
     let command = [];
     const focusWindow = atom.config.get('stata-exec.focusWindow');
@@ -436,6 +444,16 @@ module.exports = {
           return console.error('Applescript: ', command);
         }
     });
+  },
+  
+  stata_linux(selection, whichApp) {
+    const path = require('path');
+    const fs = require('fs');
+    
+    fs.writeFile(path.join(process.env.HOME, '.stata-exec_code'), selection)
+    
+    var exec = require('child_process').exec;
+    exec('autokey-run -s stata-exec');
   },
 
   xquartz(selection) {

--- a/linux/stata-exec.py
+++ b/linux/stata-exec.py
@@ -1,0 +1,18 @@
+# Enter script code
+import time
+from os.path import expanduser, join
+shortdelay = 0.2
+current = window.get_active_title()
+
+window.activate("Stata/")
+if window.wait_for_focus("Stata/(IC|SE|MP) 1[1-5].[0-2]", timeOut = 1):
+
+    cmd = open(join(expanduser('~'), '.stata-exec_code'),'r').read()
+
+    time.sleep(shortdelay)
+    keyboard.send_keys(cmd)
+    keyboard.send_keys("<enter>")
+
+    time.sleep(shortdelay)
+    window.activate(current)
+    keyboard.send_keys("<escape>")


### PR DESCRIPTION
## [1.2.0] - 2017-11-20
- Add linux support.
- Remove comments for all methods of sending code, not just 'send-command'
- Change warnings from "can't find function" to "can't find program"
- Fixes https://github.com/kylebarron/stata-exec/issues/8